### PR TITLE
updated .toc for BCC

### DIFF
--- a/CodexLite.toc
+++ b/CodexLite.toc
@@ -1,4 +1,4 @@
-## Interface: 11504
+## Interface: 11504, 20505
 ## Title: CodexLite
 ## Title-zhCN: CodexLite
 ## Title-zhTW: CodexLite


### PR DESCRIPTION
0 lua errors with this in 2.5.5